### PR TITLE
fix: make sure `--save-exact` is converted correctly

### DIFF
--- a/src/npmToYarn.ts
+++ b/src/npmToYarn.ts
@@ -8,7 +8,7 @@ const npmToYarnTable = {
     let ret = command
       .replace('install', 'add')
       .replace('--save-dev', '--dev')
-      .replace(/\s*--save/, '')
+      .replace(/\s*--save(?!-)/, '')
       .replace('--no-package-lock', '--no-lockfile')
       .replace('--save-optional', '--optional')
       .replace('--save-exact', '--exact')
@@ -22,7 +22,7 @@ const npmToYarnTable = {
     let ret = command
       .replace('uninstall', 'remove')
       .replace('--save-dev', '--dev')
-      .replace(/\s*--save/, '')
+      .replace(/\s*--save(?!-)/, '')
       .replace('--no-package-lock', '--no-lockfile')
     if (/ -(?:-global|g)(?![^\b])/.test(ret)) {
       ret = ret.replace(/ -(?:-global|g)(?![^\b])/, '')


### PR DESCRIPTION
Fixes #7 

Funny how these things go. I reported the issue then I started fixing a similar issue for npm to pnpm for https://github.com/sapphiredev/documentation-plugins/issues/80 and turns out this fix also works for npm to yarn

Example regexr: regexr.com/6phbp